### PR TITLE
Add ruleset for demorgen.be (and auto-concatenate)

### DIFF
--- a/.github/workflows/concat.yml
+++ b/.github/workflows/concat.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
+        uses: actions/checkout@v2
       - id: listup-targets
         run: |
           files=$(find rulesets -print)

--- a/.github/workflows/concat.yml
+++ b/.github/workflows/concat.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - id: listup-targets
         run: |
-          files=$(find rulesets -print)
+          files=$(find rulesets -type f -print)
           escaped_files="${files//$'\n'/\ }"
           echo "::set-output name=files::${escaped_files}"
       - name: Clear concat file

--- a/.github/workflows/concat.yml
+++ b/.github/workflows/concat.yml
@@ -24,3 +24,13 @@ jobs:
         with:
           sources: ${{ steps.listup-targets.outputs.files }}
           destination: ruleset.yaml
+      - name: Commit files
+        run: |
+          git config --local user.email "2406013+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -a -m "Add changes"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/concat.yml
+++ b/.github/workflows/concat.yml
@@ -1,0 +1,25 @@
+name: Concatenate
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+      - id: listup-targets
+        run: |
+          files=$(find rulesets -print)
+          escaped_files="${files//$'\n'/\ }"
+          echo "::set-output name=files::${escaped_files}"
+      - name: Clear concat file
+        run: |
+          rm ruleset.yaml
+      - name: Concatenate files
+        uses: ftnext/action-concatenate-files@main
+        with:
+          sources: ${{ steps.listup-targets.outputs.files }}
+          destination: ruleset.yaml

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -1,11 +1,11 @@
-- domains:
-    - www.thestar.com
-    - www.niagarafallsreview.ca
-    - www.stcatharinesstandard.ca
-    - www.thepeterboroughexaminer.com
-    - www.therecord.com
-    - www.thespec.com
-    - www.wellandtribune.ca
+- domains: 
+  - www.thestar.com
+  - www.niagarafallsreview.ca
+  - www.stcatharinesstandard.ca
+  - www.thepeterboroughexaminer.com
+  - www.therecord.com
+  - www.thespec.com
+  - www.wellandtribune.ca
   injections:
     - position: head
       append: |
@@ -33,6 +33,106 @@
             recommendations.forEach(el => { el.remove(); });
           });
         </script>
+
+- domains: 
+  - www.nytimes.com
+  - www.time.com
+  headers:
+    ueser-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+    cookie: nyt-a=; nyt-gdpr=0; nyt-geo=DE; nyt-privacy=1
+    referer: https://www.google.com/ 
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            const banners = document.querySelectorAll('div[data-testid="inline-message"], div[id^="ad-"], div[id^="leaderboard-"], div.expanded-dock, div.pz-ad-box, div[id="top-wrapper"], div[id="bottom-wrapper"]');
+            banners.forEach(el => { el.remove(); });
+          });
+        </script>
+
+- domains: 
+  - www.architecturaldigest.com
+  - www.bonappetit.com
+  - www.cntraveler.com
+  - www.epicurious.com
+  - www.gq.com
+  - www.newyorker.com
+  - www.vanityfair.com
+  - www.vogue.com
+  - www.wired.com
+  injections:
+    - position: head
+      append: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            const banners = document.querySelectorAll('.paywall-bar, div[class^="MessageBannerWrapper-"');
+            banners.forEach(el => { el.remove(); });
+          });
+        </script>
+
+- domain: americanbanker.com
+  paths:
+    - /news
+  injections:
+    - position: head
+      append: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            const inlineGate = document.querySelector('.inline-gate');
+            if (inlineGate) {
+              inlineGate.classList.remove('inline-gate');
+              const inlineGated = document.querySelectorAll('.inline-gated');
+              for (const elem of inlineGated) { elem.classList.remove('inline-gated'); }
+            }
+          });
+        </script>
+
+- domain: www.washingtonpost.com
+  injections:
+    - position: head
+      append: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            let paywall = document.querySelectorAll('div[data-qa$="-ad"], div[id="leaderboard-wrapper"], div[data-qa="subscribe-promo"]');
+            paywall.forEach(el => { el.remove(); });
+            const images = document.querySelectorAll('img');
+            images.forEach(image => { image.parentElement.style.filter = ''; });
+            const headimage = document.querySelectorAll('div .aspect-custom');
+            headimage.forEach(image => { image.style.filter = ''; });
+          });
+        </script>
+
+- domain: www.usatoday.com
+  injections:
+    - position: head
+      append: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            const banners = document.querySelectorAll('div.roadblock-container, .gnt_nb, [aria-label="advertisement"], div[id="main-frame-error"]');
+            banners.forEach(el => { el.remove(); });
+          });
+        </script>
+
+- domain: medium.com
+  headers:
+    referer: https://t.co/x?amp=1
+    x-forwarded-for: none
+    user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
+    content-security-policy: script-src 'self';
+    cookie: 
+
+# loads amp version of page
+- domain: tagesspiegel.de
+  headers:
+    content-security-policy: script-src 'self';
+    user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
+  urlMods:
+    query:
+      - key: amp
+        value: 1
+
 - domain: www.nzz.ch
   paths:
     - /international
@@ -57,94 +157,52 @@
             removeDOMElement(paywall)
           });
         </script>
-- domain: tagesspiegel.de
+
+- domains:
+  - myprivacy.dpgmedia.be
+  - myprivacy.dpgmedia.nl
   headers:
-    user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
-    content-security-policy: script-src 'self';
+    cookie: isBot=true; authId=1
+    x-forwarded-for: none
+    referer: https://news.google.com
+- domains:
+  - demorgen.be
+  headers:
+    cookie: isBot=true; authId=1
+    user-agent: Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; Googlebot-News; +http://www.google.com/bot.html) Chrome/121.0.6140.0 Safari/537.36
+    x-forwarded-for: none
+    referer: https://news.google.com
+  regexRules:
+    - match: (\s&&\s)?window\.temptation(\s&&\s)?(\.init)?(\s&&\s)?(\(([^)]\s*)*\);)?
+      replace: true
+  injections:
+    - position: head
+      prepend: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            let paywall = document.querySelectorAll('script[src*="advertising-cdn.dpgmedia.cloud"], div[data-temptation-position="ARTICLE_BOTTOM"]');
+            paywall.forEach(el => { el.remove(); });
+          });
+        </script>
+
 - domain: www.ft.com
   headers:
     referer: https://t.co/x?amp=1
   injections:
     - position: head
-      append: "<script>\n  document.addEventListener(\"DOMContentLoaded\", () => {\n    const styleTags = document.querySelectorAll('link[rel=\"stylesheet\"]');\n    styleTags.forEach(el => { \n      const href = el.getAttribute('href').substring(1);\n      const updatedHref = href.replace(/(https?:\\/\\/.+?)\\/{2,}/, '$1/');\n      el.setAttribute('href', updatedHref);\n    });\n    setTimeout(() => {\n      const cookie = document.querySelectorAll('.o-cookie-message, .js-article-ribbon, .o-ads, .o-banner, .o-message, .article__content-sign-up');\n      cookie.forEach(el => { el.remove(); });\n    }, 1000);\n  })\n</script>\n"
-- domains:
-    - www.architecturaldigest.com
-    - www.bonappetit.com
-    - www.cntraveler.com
-    - www.epicurious.com
-    - www.gq.com
-    - www.newyorker.com
-    - www.vanityfair.com
-    - www.vogue.com
-    - www.wired.com
-  injections:
-    - position: head
       append: |
         <script>
           document.addEventListener("DOMContentLoaded", () => {
-            const banners = document.querySelectorAll('.paywall-bar, div[class^="MessageBannerWrapper-"');
-            banners.forEach(el => { el.remove(); });
-          });
+            const styleTags = document.querySelectorAll('link[rel="stylesheet"]');
+            styleTags.forEach(el => { 
+              const href = el.getAttribute('href').substring(1);
+              const updatedHref = href.replace(/(https?:\/\/.+?)\/{2,}/, '$1/');
+              el.setAttribute('href', updatedHref);
+            });
+            setTimeout(() => {
+              const cookie = document.querySelectorAll('.o-cookie-message, .js-article-ribbon, .o-ads, .o-banner, .o-message, .article__content-sign-up');
+              cookie.forEach(el => { el.remove(); });
+            }, 1000);
+          })
         </script>
-- domain: americanbanker.com
-  paths:
-    - /news
-  injections:
-    - position: head
-      append: |
-        <script>
-          document.addEventListener("DOMContentLoaded", () => {
-            const inlineGate = document.querySelector('.inline-gate');
-            if (inlineGate) {
-              inlineGate.classList.remove('inline-gate');
-              const inlineGated = document.querySelectorAll('.inline-gated');
-              for (const elem of inlineGated) { elem.classList.remove('inline-gated'); }
-            }
-          });
-        </script>
-- domain: medium.com
-  headers:
-    user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
-    x-forwarded-for: none
-    referer: https://t.co/x?amp=1
-    content-security-policy: script-src 'self';
-- domains:
-    - www.nytimes.com
-    - www.time.com
-  headers:
-    referer: https://www.google.com/
-    cookie: nyt-a=; nyt-gdpr=0; nyt-geo=DE; nyt-privacy=1
-  injections:
-    - position: head
-      append: |
-        <script>
-          window.localStorage.clear();
-          document.addEventListener("DOMContentLoaded", () => {
-            const banners = document.querySelectorAll('div[data-testid="inline-message"], div[id^="ad-"], div[id^="leaderboard-"], div.expanded-dock, div.pz-ad-box, div[id="top-wrapper"], div[id="bottom-wrapper"]');
-            banners.forEach(el => { el.remove(); });
-          });
-        </script>
-- domain: www.usatoday.com
-  injections:
-    - position: head
-      append: |
-        <script>
-          document.addEventListener("DOMContentLoaded", () => {
-            const banners = document.querySelectorAll('div.roadblock-container, .gnt_nb, [aria-label="advertisement"], div[id="main-frame-error"]');
-            banners.forEach(el => { el.remove(); });
-          });
-        </script>
-- domain: www.washingtonpost.com
-  injections:
-    - position: head
-      append: |
-        <script>
-          document.addEventListener("DOMContentLoaded", () => {
-            let paywall = document.querySelectorAll('div[data-qa$="-ad"], div[id="leaderboard-wrapper"], div[data-qa="subscribe-promo"]');
-            paywall.forEach(el => { el.remove(); });
-            const images = document.querySelectorAll('img');
-            images.forEach(image => { image.parentElement.style.filter = ''; });
-            const headimage = document.querySelectorAll('div .aspect-custom');
-            headimage.forEach(image => { image.style.filter = ''; });
-          });
-        </script>
+

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -180,8 +180,11 @@
       prepend: |
         <script>
           document.addEventListener("DOMContentLoaded", () => {
+            // remove paywall items
             let paywall = document.querySelectorAll('script[src*="advertising-cdn.dpgmedia.cloud"], div[data-temptation-position="ARTICLE_BOTTOM"]');
             paywall.forEach(el => { el.remove(); });
+            // remove empty advert
+            document.querySelector('div[data-advert-placeholder-collapses]').remove();
           });
         </script>
 

--- a/rulesets/be/dpgmedia.yaml
+++ b/rulesets/be/dpgmedia.yaml
@@ -20,7 +20,10 @@
       prepend: |
         <script>
           document.addEventListener("DOMContentLoaded", () => {
+            // remove paywall items
             let paywall = document.querySelectorAll('script[src*="advertising-cdn.dpgmedia.cloud"], div[data-temptation-position="ARTICLE_BOTTOM"]');
             paywall.forEach(el => { el.remove(); });
+            // remove empty advert
+            document.querySelector('div[data-advert-placeholder-collapses]').remove();
           });
         </script>

--- a/rulesets/be/dpgmedia.yaml
+++ b/rulesets/be/dpgmedia.yaml
@@ -1,0 +1,26 @@
+- domains:
+  - myprivacy.dpgmedia.be
+  - myprivacy.dpgmedia.nl
+  headers:
+    cookie: isBot=true; authId=1
+    x-forwarded-for: none
+    referer: https://news.google.com
+- domains:
+  - demorgen.be
+  headers:
+    cookie: isBot=true; authId=1
+    user-agent: Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; Googlebot-News; +http://www.google.com/bot.html) Chrome/121.0.6140.0 Safari/537.36
+    x-forwarded-for: none
+    referer: https://news.google.com
+  regexRules:
+    - match: (\s&&\s)?window\.temptation(\s&&\s)?(\.init)?(\s&&\s)?(\(([^)]\s*)*\);)?
+      replace: true
+  injections:
+    - position: head
+      prepend: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            let paywall = document.querySelectorAll('script[src*="advertising-cdn.dpgmedia.cloud"], div[data-temptation-position="ARTICLE_BOTTOM"]');
+            paywall.forEach(el => { el.remove(); });
+          });
+        </script>


### PR DESCRIPTION
The ruleset for `demorgen.be` might also work on other DPG Media Group news websites. To be tested

Also adds a GitHub automation to automatically concatenate the different rulesets into `ruleset.yaml`