### PR TITLE
feat: add `lemonde.fr` ruleset

### DIFF
--- a/rulesets/fr/lemonde.yaml
+++ b/rulesets/fr/lemonde.yaml
@@ -10,7 +10,11 @@
         <script>
           window.localStorage.clear();
           document.addEventListener("DOMContentLoaded", () => {
-            const banners = document.querySelectorAll('div.article__content--restricted-media, section.paywall');
+            const banners = document.querySelectorAll('section.paywall');
             banners.forEach(el => { el.remove(); });
+            const contentWrapper = document.querySelectorAll('section.article__content--restricted-media');
+            if (contentWrapper?.[0]) {
+              contentWrapper[0].style.height = '100%'
+            }
           });
         </script>

--- a/rulesets/fr/lemonde.yaml
+++ b/rulesets/fr/lemonde.yaml
@@ -1,0 +1,16 @@
+- domains: 
+  - www.lemonde.fr
+  headers:
+    user-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+    referer: https://www.google.com/ 
+    content-security-policy: "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:;"
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            const banners = document.querySelectorAll('div.article__content--restricted-media, section.paywall');
+            banners.forEach(el => { el.remove(); });
+          });
+        </script>

--- a/rulesets/us/nytimes-com.yaml
+++ b/rulesets/us/nytimes-com.yaml
@@ -2,7 +2,7 @@
   - www.nytimes.com
   - www.time.com
   headers:
-    ueser-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+    user-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
     cookie: nyt-a=; nyt-gdpr=0; nyt-geo=DE; nyt-privacy=1
     referer: https://www.google.com/ 
     content-security-policy: "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:;"


### PR DESCRIPTION
- Primarily adds a simple ruleset for Le Monde (https://www.lemonde.fr), a large French newspaper
	- Example paywalled article: https://www.lemonde.fr/economie/article/2023/11/28/le-jeu-risque-de-david-layani-de-nicolas-sarkozy-au-groupe-atos_6202778_3234.html
- Also fixes a small typo in the nytimes ruleset.