### PR TITLE
Fix concat workflow permissions and tagesspiegel tests shape

### DIFF
--- a/.github/workflows/concat.yml
+++ b/.github/workflows/concat.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     if: "!contains(github.event.*.labels.*.name, 'automated-pr')"

--- a/rulesets/de/tagesspiegel-de.yaml
+++ b/rulesets/de/tagesspiegel-de.yaml
@@ -8,5 +8,5 @@
       - key: amp
         value: 1
   tests:
-    url: https://www.tagesspiegel.de/politik/impfungen-in-deutschland-und-der-welt-der-aktuelle-stand-der-impfkampagne/26809888.html
-    test: document.querySelector('html').classList.contains('amp-mode')
+    - url: https://www.tagesspiegel.de/politik/impfungen-in-deutschland-und-der-welt-der-aktuelle-stand-der-impfkampagne/26809888.html
+      test: document.querySelector('html').classList.contains('amp-mode')


### PR DESCRIPTION
## Summary
- fix `rulesets/de/tagesspiegel-de.yaml` so `tests` is an array entry (consistent with the rest of the rulesets)
- add explicit workflow permissions in `.github/workflows/concat.yml`:
  - `contents: write`
  - `pull-requests: write`

## Why
- concat workflow runs failed on push with git exit code 128 during PR automation
- explicit write permissions are required for `create-pull-request` + `gh pr merge --auto`

## Scope
- no behavior changes outside these two targeted fixes